### PR TITLE
fix(filter): close fail-open identity branch and route Discord replies

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -294,6 +294,13 @@ export interface DiscordMessage {
   content: string;
   timestamp: string;
   attachments?: DiscordAttachment[];
+  /**
+   * Populated by Discord when this message is a reply (type 19). Contains the
+   * parent message object so the watcher can route replies to whoever signed
+   * the parent, even when the reply text doesn't include an @<dev-name> token.
+   * `null` when the parent has been deleted.
+   */
+  referenced_message?: DiscordMessage | null;
 }
 
 // --- Voice message STT -------------------------------------------------------
@@ -301,6 +308,103 @@ export interface DiscordMessage {
 /** Strip punctuation from a lowercased token, keeping only routing-key chars. */
 export function stripTokenPunctuation(token: string): string {
   return token.replace(/[^a-z0-9@_-]/g, "");
+}
+
+/**
+ * Strip fenced code blocks and inline code spans from a markdown string.
+ * Used to prevent false-positive signature matches when a message quotes
+ * the signature format in a code block (e.g. "the format is `— **morpheus**`").
+ */
+function stripMarkdownCode(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, "") // fenced code blocks
+    .replace(/`[^`\n]*`/g, "");     // inline code spans
+}
+
+/**
+ * Check whether a message is a reply to another message we (the current
+ * agent identity) signed. Looks at `referenced_message.content` for the
+ * signature pattern `— **<dev-name>**` (case-insensitive), with markdown
+ * code blocks and inline code spans stripped first to avoid false positives
+ * from quoted signature examples.
+ *
+ * Replies in Discord carry their addressing in `referenced_message`, not in
+ * the reply's text content. Without this check, a reply like "good point" to
+ * a message we just posted would be silently dropped by the token-based
+ * filter — even though Discord's UI clearly shows it as directed at us.
+ */
+export function isReplyToOurSignature(
+  msg: DiscordMessage,
+  identity: AgentIdentity
+): boolean {
+  const parent = msg.referenced_message;
+  if (!parent || !parent.content || !identity.devName) return false;
+  const cleaned = stripMarkdownCode(parent.content).toLowerCase();
+  return cleaned.includes(`— **${identity.devName.toLowerCase()}**`);
+}
+
+/**
+ * Pure-function targeted routing filter. Returns true if the message should
+ * be delivered as a wake-up notification to the current agent, false otherwise.
+ *
+ * Decision order (the fail-closed identity check intentionally precedes
+ * VERBOSE so that an unattributed agent gets nothing even in verbose mode —
+ * VERBOSE bypasses targeted routing, not security boundaries):
+ *   1. Empty messages (no content, no attachments) → drop
+ *   2. Self-echo (message contains our own signature) → drop
+ *   3. Identity unresolved (no devName, no devTeam) → drop (fail closed,
+ *      prevents cross-project leakage to unattributed sessions)
+ *   4. VERBOSE mode bypasses targeted routing → deliver
+ *   5. Addressed via @all, @<dev-team>, @<dev-name>, or reply to a message
+ *      we signed → deliver
+ *   6. Otherwise → drop
+ */
+export function shouldDeliverMessage(
+  msg: DiscordMessage,
+  identity: AgentIdentity,
+  options: { verbose?: boolean } = {}
+): boolean {
+  // 1. Skip empty messages (e.g. bot embeds, sticker-only)
+  if (!msg.content.trim() && !msg.attachments?.length) {
+    return false;
+  }
+
+  // 2. Self-echo filter — drop messages containing our own signature
+  if (
+    identity.devName &&
+    msg.content
+      .toLowerCase()
+      .includes(`— **${identity.devName.toLowerCase()}**`)
+  ) {
+    return false;
+  }
+
+  // 3. Fail closed when identity is unresolved (precedes VERBOSE so the
+  // security boundary is preserved even in verbose mode)
+  if (!identity.devName && !identity.devTeam) {
+    return false;
+  }
+
+  // 4. VERBOSE mode bypasses targeted routing entirely
+  if (options.verbose) {
+    return true;
+  }
+
+  // 5. Token-based addressing
+  const tokens = msg.content
+    .toLowerCase()
+    .split(/\s+/)
+    .map(stripTokenPunctuation);
+  const isAddressedToAll = tokens.includes("@all");
+  const isAddressedToTeam = identity.devTeam
+    ? tokens.includes(`@${identity.devTeam.toLowerCase()}`)
+    : false;
+  const isAddressedToMe = identity.devName
+    ? tokens.includes(`@${identity.devName.toLowerCase()}`)
+    : false;
+  const replyToUs = isReplyToOurSignature(msg, identity);
+
+  return isAddressedToAll || isAddressedToTeam || isAddressedToMe || replyToUs;
 }
 
 const STT_ENDPOINT = process.env.STT_ENDPOINT ?? "http://archer:8300/v1/audio/transcriptions";
@@ -505,37 +609,8 @@ async function checkForNewMessages(
 
       // Push a wake-up notification for each new message (oldest first)
       for (const msg of messages.reverse()) {
-        // Skip messages with no text and no attachments (e.g. bot embeds)
-        if (!msg.content.trim() && !msg.attachments?.length) {
+        if (!shouldDeliverMessage(msg, cachedIdentity, { verbose: VERBOSE })) {
           continue;
-        }
-
-        // Self-echo filter: skip messages containing our own signature (case-insensitive)
-        if (cachedIdentity.devName &&
-            msg.content.toLowerCase().includes(`— **${cachedIdentity.devName.toLowerCase()}**`)) {
-          continue;
-        }
-
-        // Targeted filtering (unless VERBOSE mode bypasses it)
-        if (!VERBOSE) {
-          // If identity hasn't been set yet, fail open — deliver the message
-          if (!cachedIdentity.devName && !cachedIdentity.devTeam) {
-            // No identity resolved yet — deliver all messages until agent sets up
-          } else {
-            const contentLower = msg.content.toLowerCase();
-            const tokens = contentLower.split(/\s+/).map(stripTokenPunctuation);
-            const isAddressedToAll = tokens.includes("@all");
-            const isAddressedToTeam = cachedIdentity.devTeam
-              ? tokens.includes(`@${cachedIdentity.devTeam.toLowerCase()}`)
-              : false;
-            const isAddressedToMe = cachedIdentity.devName
-              ? tokens.includes(`@${cachedIdentity.devName.toLowerCase()}`)
-              : false;
-
-            if (!isAddressedToAll && !isAddressedToTeam && !isAddressedToMe) {
-              continue;
-            }
-          }
         }
 
         // Transcribe audio attachments if present
@@ -579,11 +654,11 @@ async function checkForNewMessages(
 
 const INSTRUCTIONS = [
   'Discord messages arrive as <channel source="discord_watcher" channel_name="..." channel_id="..." author="...">.',
-  "Messages are pre-filtered: you only receive messages addressed to @all, @<Dev-Team>, or @<Dev-Name>.",
+  "Messages are pre-filtered: you only receive messages addressed to @all, @<Dev-Team>, @<Dev-Name>, or replies to messages you signed.",
   "When you see a notification:",
   "1. Run: discord-bot read <channel_id> --limit 10",
   "2. Process the message and respond via discord-bot send if action is needed.",
-  '3. Sign every message with: — **<dev-name>** <dev-avatar> (<dev-team>). The watcher filters your own echoes by this signature.',
+  '3. Sign every message with: — **<dev-name>** <dev-avatar> (<dev-team>). The watcher filters your own echoes by this signature, and uses it to route replies back to you.',
 ].join("\n");
 
 async function main(): Promise<void> {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -17,8 +17,11 @@ import {
   engageKillSwitch,
   checkScreamHoleHealth,
   resolveApiBase,
+  shouldDeliverMessage,
+  isReplyToOurSignature,
   DISCORD_API_BASE,
 } from "../index";
+import type { AgentIdentity } from "../index";
 
 // We need to mock fetch and fs before importing the module under test.
 // Bun's mock system lets us intercept global fetch.
@@ -391,6 +394,273 @@ describe("addressing", () => {
     expect(tokens).toContain("@echo-chamber");
     expect(tokens).toContain("@all");
     expect(tokens).toContain("@cc-workflow");
+  });
+});
+
+// --- shouldDeliverMessage / isReplyToOurSignature tests ---------------------
+//
+// Filter-correctness regression suite for issue #10. Both fixes:
+//   1. Fail-closed when identity is unresolved (was: fail-open, leaked
+//      cross-project messages to unattributed sessions)
+//   2. Reply-routing via referenced_message signature match (was: replies
+//      with no @-mention in their text were silently dropped)
+
+describe("shouldDeliverMessage", () => {
+  const identity = (overrides: Partial<AgentIdentity> = {}): AgentIdentity => ({
+    devName: "morpheus",
+    devTeam: "mcp-server-discord-watcher",
+    ...overrides,
+  });
+
+  test("delivers message addressed to @<dev-name>", () => {
+    const msg = makeMsg({ content: "hey @morpheus check this" });
+    expect(shouldDeliverMessage(msg, identity())).toBe(true);
+  });
+
+  test("delivers message addressed to @<dev-team>", () => {
+    const msg = makeMsg({ content: "hey @mcp-server-discord-watcher ship it" });
+    expect(shouldDeliverMessage(msg, identity())).toBe(true);
+  });
+
+  test("delivers message addressed to @all", () => {
+    const msg = makeMsg({ content: "@all standup in 5" });
+    expect(shouldDeliverMessage(msg, identity())).toBe(true);
+  });
+
+  test("addressing matches even with trailing punctuation", () => {
+    const msg = makeMsg({ content: "@morpheus, can you look at this?" });
+    expect(shouldDeliverMessage(msg, identity())).toBe(true);
+  });
+
+  test("drops unaddressed message when identity is set", () => {
+    const msg = makeMsg({ content: "random chatter with no addressing" });
+    expect(shouldDeliverMessage(msg, identity())).toBe(false);
+  });
+
+  test("drops empty message (no content, no attachments)", () => {
+    const msg = makeMsg({ content: "" });
+    expect(shouldDeliverMessage(msg, identity())).toBe(false);
+  });
+
+  test("delivers message with audio attachment even if content is empty", () => {
+    const msg = makeMsg({
+      content: "@morpheus listen to this",
+      attachments: [
+        {
+          id: "a1",
+          filename: "voice.ogg",
+          content_type: "audio/ogg",
+          url: "https://example.com/voice.ogg",
+          size: 1024,
+        },
+      ],
+    });
+    expect(shouldDeliverMessage(msg, identity())).toBe(true);
+  });
+
+  // --- Bug 1 fix: fail-closed when identity unresolved ---
+
+  test("FAIL CLOSED: drops message when both devName and devTeam are null", () => {
+    const msg = makeMsg({ content: "@some-other-agent please help" });
+    const noIdentity = { devName: null, devTeam: null };
+    expect(shouldDeliverMessage(msg, noIdentity)).toBe(false);
+  });
+
+  test("FAIL CLOSED: drops even @all when identity is unresolved", () => {
+    // The most surprising case: even broadcasts fail closed for unidentified
+    // agents. Better silence than cross-project leakage.
+    const msg = makeMsg({ content: "@all standup in 5" });
+    const noIdentity = { devName: null, devTeam: null };
+    expect(shouldDeliverMessage(msg, noIdentity)).toBe(false);
+  });
+
+  test("FAIL CLOSED: still delivers when at least devTeam is resolved", () => {
+    const msg = makeMsg({ content: "@my-team ship it" });
+    const partialIdentity = { devName: null, devTeam: "my-team" };
+    expect(shouldDeliverMessage(msg, partialIdentity)).toBe(true);
+  });
+
+  // --- Self-echo filter still works ---
+
+  test("self-echo: drops messages containing our own signature", () => {
+    const msg = makeMsg({
+      content: "did the thing — **morpheus** 💊 (mcp-server-discord-watcher)",
+    });
+    expect(shouldDeliverMessage(msg, identity())).toBe(false);
+  });
+
+  test("self-echo is case-insensitive", () => {
+    const msg = makeMsg({ content: "did the thing — **MORPHEUS** 💊" });
+    expect(shouldDeliverMessage(msg, identity())).toBe(false);
+  });
+
+  // --- VERBOSE mode ---
+
+  test("VERBOSE bypasses targeted routing", () => {
+    const msg = makeMsg({ content: "random chatter" });
+    expect(shouldDeliverMessage(msg, identity(), { verbose: true })).toBe(true);
+  });
+
+  test("VERBOSE still applies self-echo filter", () => {
+    const msg = makeMsg({ content: "echo — **morpheus** 💊" });
+    expect(shouldDeliverMessage(msg, identity(), { verbose: true })).toBe(false);
+  });
+
+  test("VERBOSE still applies empty-message filter", () => {
+    const msg = makeMsg({ content: "" });
+    expect(shouldDeliverMessage(msg, identity(), { verbose: true })).toBe(false);
+  });
+
+  test("FAIL CLOSED takes precedence over VERBOSE", () => {
+    // VERBOSE bypasses targeted routing, NOT the security boundary.
+    // An unattributed agent must not receive cross-project traffic just
+    // because someone set DISCORD_WATCHER_VERBOSE=1.
+    const msg = makeMsg({ content: "@all standup in 5" });
+    const noIdentity = { devName: null, devTeam: null };
+    expect(shouldDeliverMessage(msg, noIdentity, { verbose: true })).toBe(false);
+  });
+
+  // --- Bug 2 fix: reply routing via referenced_message ---
+
+  test("REPLY-ROUTING: delivers reply to a message we signed", () => {
+    const msg = makeMsg({
+      content: "good point",
+      referenced_message: makeMsg({
+        id: "parent-1",
+        content: "the fix is at index.ts:520. — **morpheus** 💊 (mcp-server-discord-watcher)",
+      }),
+    });
+    expect(shouldDeliverMessage(msg, identity())).toBe(true);
+  });
+
+  test("REPLY-ROUTING: does not deliver reply to someone else's message", () => {
+    const msg = makeMsg({
+      content: "thanks",
+      referenced_message: makeMsg({
+        id: "parent-1",
+        content: "fix landed. — **cacodemon** 👁️ (mcp-server-nerf)",
+      }),
+    });
+    expect(shouldDeliverMessage(msg, identity())).toBe(false);
+  });
+
+  test("REPLY-ROUTING is case-insensitive", () => {
+    const msg = makeMsg({
+      content: "got it",
+      referenced_message: makeMsg({
+        id: "parent-1",
+        content: "look here — **MORPHEUS** 💊",
+      }),
+    });
+    expect(shouldDeliverMessage(msg, identity())).toBe(true);
+  });
+
+  test("REPLY-ROUTING: missing referenced_message is harmless", () => {
+    const msg = makeMsg({ content: "no reference" });
+    // Same as the unaddressed-drop case
+    expect(shouldDeliverMessage(msg, identity())).toBe(false);
+  });
+
+  test("REPLY-ROUTING: null referenced_message (parent deleted) is harmless", () => {
+    const msg = makeMsg({ content: "no reference", referenced_message: null });
+    expect(shouldDeliverMessage(msg, identity())).toBe(false);
+  });
+
+  test("REPLY-ROUTING: delivers when reply is also addressed to a third party", () => {
+    // Documented intent: a reply to one of our messages is for us, even if
+    // the reply text mentions someone else by name. Discord's threading
+    // model puts the sender in conversation with the parent's author.
+    const msg = makeMsg({
+      content: "@cacodemon you should see this too",
+      referenced_message: makeMsg({
+        id: "parent-1",
+        content: "the fix landed — **morpheus** 💊 (mcp-server-discord-watcher)",
+      }),
+    });
+    expect(shouldDeliverMessage(msg, identity())).toBe(true);
+  });
+});
+
+describe("isReplyToOurSignature", () => {
+  const identity: AgentIdentity = {
+    devName: "morpheus",
+    devTeam: "mcp-server-discord-watcher",
+  };
+
+  test("returns false when message has no referenced_message", () => {
+    const msg = makeMsg({ content: "hi" });
+    expect(isReplyToOurSignature(msg, identity)).toBe(false);
+  });
+
+  test("returns false when referenced_message is null", () => {
+    const msg = makeMsg({ content: "hi", referenced_message: null });
+    expect(isReplyToOurSignature(msg, identity)).toBe(false);
+  });
+
+  test("returns false when referenced_message has empty content", () => {
+    const msg = makeMsg({
+      content: "hi",
+      referenced_message: makeMsg({ content: "" }),
+    });
+    expect(isReplyToOurSignature(msg, identity)).toBe(false);
+  });
+
+  test("returns false when identity has no devName", () => {
+    const msg = makeMsg({
+      content: "hi",
+      referenced_message: makeMsg({ content: "— **morpheus** 💊" }),
+    });
+    expect(isReplyToOurSignature(msg, { devName: null, devTeam: "team" })).toBe(false);
+  });
+
+  test("returns true when parent contains our signature", () => {
+    const msg = makeMsg({
+      content: "hi",
+      referenced_message: makeMsg({
+        content: "look at this — **morpheus** 💊 (team)",
+      }),
+    });
+    expect(isReplyToOurSignature(msg, identity)).toBe(true);
+  });
+
+  test("does not match a partial signature without the em-dash prefix", () => {
+    const msg = makeMsg({
+      content: "hi",
+      referenced_message: makeMsg({ content: "the **morpheus** project is cool" }),
+    });
+    expect(isReplyToOurSignature(msg, identity)).toBe(false);
+  });
+
+  test("ignores signature inside an inline code span in parent", () => {
+    // A message discussing the signature format should NOT trigger reply-routing
+    const msg = makeMsg({
+      content: "got it",
+      referenced_message: makeMsg({
+        content: "the format is `— **morpheus** 💊` — see the docs",
+      }),
+    });
+    expect(isReplyToOurSignature(msg, identity)).toBe(false);
+  });
+
+  test("ignores signature inside a fenced code block in parent", () => {
+    const msg = makeMsg({
+      content: "got it",
+      referenced_message: makeMsg({
+        content: "example signature:\n```\n— **morpheus** 💊 (team)\n```\nuse it everywhere",
+      }),
+    });
+    expect(isReplyToOurSignature(msg, identity)).toBe(false);
+  });
+
+  test("still matches signature outside code spans even if a code span exists", () => {
+    // Real signature is outside the code block; the code block contains other content
+    const msg = makeMsg({
+      content: "thanks",
+      referenced_message: makeMsg({
+        content: "fix is at `index.ts:520` — **morpheus** 💊 (team)",
+      }),
+    });
+    expect(isReplyToOurSignature(msg, identity)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Bug 1 — fail-open closed.** When an agent had no resolved identity (`/name` not yet run), the watcher's filter delivered every message in every channel. This caused real cross-project leakage in the session that filed #10. Now fails closed: drop the message instead.
- **Bug 2 — reply routing.** Discord replies carry their addressing in `referenced_message`, not in the reply text. The filter now scans `referenced_message.content` for the agent's `— **<dev-name>**` signature, with markdown code spans stripped to avoid false positives from quoted signature examples.
- **Refactor.** Extracted the inline filter from inside `checkForNewMessages` into an exported pure function `shouldDeliverMessage(msg, identity, options)` so the routing decision is unit-testable in isolation. Decision order is documented in JSDoc; fail-closed precedes VERBOSE so the security boundary holds even in verbose mode.

## Changes

- `index.ts`: +124/-32. New exports `shouldDeliverMessage`, `isReplyToOurSignature`. New file-private `stripMarkdownCode` helper. New `DiscordMessage.referenced_message?: DiscordMessage | null` field. `INSTRUCTIONS` string updated to mention reply-routing as a fourth delivery condition for downstream agents.
- `tests/index.test.ts`: +258 lines, 31 new tests. Two new describe blocks (`shouldDeliverMessage`, `isReplyToOurSignature`) covering positive token routing, fail-closed boundary including `@all` edge case, VERBOSE precedence (including the explicit "fail-closed takes precedence over VERBOSE" boundary test), reply routing including code-span isolation and third-party-mention intent test, and helper unit tests.

## Linked Issues

Closes #10

## Test Plan

- [x] `scripts/ci/validate.sh` — clean (shellcheck on 7 scripts, `bun run lint` strict-mode TypeScript, `bun test`)
- [x] `bun test` — 72 pass / 0 fail (was 39 before)
- [x] `feature-dev:code-reviewer` agent run; 3 substantive findings fixed (VERBOSE precedence, code-span false positive, test gap), 1 informational (recursive type) deferred with rationale in code review thread
- [x] Manual repro of Bug 1 confirmed in the same session that filed the issue: `blueshift-storage` precheck notification landed in this `mcp-server-discord-watcher` session before identity was resolved
- [ ] Bug 2 reply-routing fix not yet manually exercised end-to-end against live Discord — covered by unit tests; will validate in next watcher restart cycle