### PR TITLE
fix(poll): add inter-channel jitter and kill-switch-aware refresh

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -97,6 +97,13 @@ const CHANNEL_REFRESH_MS = 5 * 60_000;
 const MESSAGES_PER_PAGE = 50;
 const VERBOSE = process.env.DISCORD_WATCHER_VERBOSE === "1";
 
+// Random delay between per-channel polls within a single cycle. Spreads
+// outbound Discord API calls across the cycle window so guilds with many
+// channels don't fire 20+ requests in a tight burst that trips the global
+// rate limit.
+const INTER_CHANNEL_JITTER_MIN_MS = 50;
+const INTER_CHANNEL_JITTER_MAX_MS = 150;
+
 // --- Kill switch -------------------------------------------------------------
 
 const KILL_FILE = join(homedir(), ".claude", "discord-bot.kill");
@@ -527,6 +534,25 @@ async function initializeBaselines(authHeader: string): Promise<void> {
 
 // --- Polling -----------------------------------------------------------------
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Returns a random delay (in milliseconds) to insert between per-channel
+ * polls in a single cycle. Used to spread Discord API calls and avoid the
+ * tight-burst pattern that can trip global rate limits on guilds with many
+ * channels.
+ *
+ * Range: [INTER_CHANNEL_JITTER_MIN_MS, INTER_CHANNEL_JITTER_MAX_MS).
+ */
+export function nextChannelJitterMs(): number {
+  return (
+    INTER_CHANNEL_JITTER_MIN_MS +
+    Math.random() * (INTER_CHANNEL_JITTER_MAX_MS - INTER_CHANNEL_JITTER_MIN_MS)
+  );
+}
+
 async function fetchAllNewMessages(
   channelId: string,
   afterId: string,
@@ -568,6 +594,45 @@ async function fetchAllNewMessages(
   return allMessages;
 }
 
+/**
+ * Refresh the watched channel list. Honors the kill switch — when the
+ * watcher is in cooldown after a 429, this is a no-op so the refresh
+ * timer doesn't independently re-burst the API while the main poll loop
+ * is paused.
+ *
+ * Mutates module-level `watchedChannels` and `lastSeenMessageId` on
+ * successful refresh. Exported so the kill-switch short-circuit can be
+ * exercised in unit tests.
+ */
+export async function refreshChannelList(authHeader: string): Promise<void> {
+  if (checkKillSwitch() === "active") return;
+
+  const fresh = await fetchTextChannels(authHeader);
+  for (const ch of fresh) {
+    // Re-check kill switch between baseline calls — if a baseline
+    // request inside this loop trips a 429 and engages the kill switch,
+    // we should stop firing more requests in the same refresh cycle
+    // rather than continue bursting through every newly discovered channel.
+    if (checkKillSwitch() === "active") break;
+
+    if (!lastSeenMessageId.has(ch.id)) {
+      try {
+        const result = await apiGet(recentMessageUrl(ch.id), authHeader);
+        if (result.ok) {
+          const msgs = result.data as DiscordMessage[];
+          if (msgs.length > 0) {
+            lastSeenMessageId.set(ch.id, msgs[0].id);
+          }
+        }
+      } catch {
+        // skip unreadable
+      }
+    }
+  }
+  watchedChannels = fresh;
+  console.error(`[discord-watcher] Refreshed: ${fresh.length} channels`);
+}
+
 async function checkForNewMessages(
   server: Server,
   authHeader: string
@@ -578,7 +643,18 @@ async function checkForNewMessages(
   // Refresh identity each cycle (agent may pick name after server starts)
   cachedIdentity = resolveIdentity();
 
+  let isFirstChannel = true;
   for (const channel of watchedChannels) {
+    // Inter-channel jitter — spread outbound API calls across the cycle
+    // window so guilds with many channels don't fire 20+ requests in a
+    // tight burst. Skipped on the first channel (no preceding work) and
+    // applied via top-of-loop placement so it covers ALL code paths in
+    // the iteration body, including the early `continue`s below.
+    if (!isFirstChannel) {
+      await sleep(nextChannelJitterMs());
+    }
+    isFirstChannel = false;
+
     try {
       const lastId = lastSeenMessageId.get(channel.id);
 
@@ -704,35 +780,12 @@ async function main(): Promise<void> {
     POLL_INTERVAL_MS
   );
 
-  // Periodically refresh the channel list
-  const refreshTimer = setInterval(async () => {
-    try {
-      const fresh = await fetchTextChannels(authHeader);
-      for (const ch of fresh) {
-        if (!lastSeenMessageId.has(ch.id)) {
-          try {
-            const result = await apiGet(
-              recentMessageUrl(ch.id),
-              authHeader
-            );
-            if (result.ok) {
-              const msgs = result.data as DiscordMessage[];
-              if (msgs.length > 0) {
-                lastSeenMessageId.set(ch.id, msgs[0].id);
-              }
-            }
-          } catch {
-            // skip unreadable
-          }
-        }
-      }
-      watchedChannels = fresh;
-      console.error(
-        `[discord-watcher] Refreshed: ${fresh.length} channels`
-      );
-    } catch (err) {
+  // Periodically refresh the channel list (honors kill switch via
+  // refreshChannelList — see its docstring)
+  const refreshTimer = setInterval(() => {
+    refreshChannelList(authHeader).catch((err) => {
       console.error(`[discord-watcher] Channel refresh failed: ${err}`);
-    }
+    });
   }, CHANNEL_REFRESH_MS);
 
   // Clean up on exit

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -19,6 +19,8 @@ import {
   resolveApiBase,
   shouldDeliverMessage,
   isReplyToOurSignature,
+  nextChannelJitterMs,
+  refreshChannelList,
   DISCORD_API_BASE,
 } from "../index";
 import type { AgentIdentity } from "../index";
@@ -661,6 +663,106 @@ describe("isReplyToOurSignature", () => {
       }),
     });
     expect(isReplyToOurSignature(msg, identity)).toBe(true);
+  });
+});
+
+// --- Polling rate-limit hygiene tests ----------------------------------------
+//
+// Regression suite for issue #9. Two fixes:
+//   1. Inter-channel jitter — checkForNewMessages now sleeps a random
+//      50-150ms between channel polls to spread API calls across the cycle
+//   2. Kill-switch-aware refresh — the channel refresh setInterval now
+//      short-circuits when the kill switch is active, instead of independently
+//      re-bursting the API while the main poll loop is paused
+
+describe("nextChannelJitterMs", () => {
+  test("returns a value in [50, 150) for many samples", () => {
+    // Sample 200 times to get good distribution coverage
+    for (let i = 0; i < 200; i++) {
+      const ms = nextChannelJitterMs();
+      expect(ms).toBeGreaterThanOrEqual(50);
+      expect(ms).toBeLessThan(150);
+    }
+  });
+
+  test("produces variation across calls (not a constant)", () => {
+    // Verify the function actually randomizes — not stuck on a single value
+    const samples = new Set<number>();
+    for (let i = 0; i < 50; i++) {
+      samples.add(nextChannelJitterMs());
+    }
+    // With Math.random producing 50 doubles in [50,150), we should get
+    // far more than a handful of distinct values. Loose bound to avoid flakes.
+    expect(samples.size).toBeGreaterThan(10);
+  });
+});
+
+describe("refreshChannelList", () => {
+  let originalFetch: typeof globalThis.fetch;
+  const KILL_FILE = `${process.env.HOME}/.claude/discord-bot.kill`;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    const { unlinkSync } = await import("node:fs");
+    try { unlinkSync(KILL_FILE); } catch { /* ignore */ }
+  });
+
+  test("returns early without calling fetch when kill switch is active", async () => {
+    const { writeFileSync, mkdirSync } = await import("node:fs");
+    mkdirSync(`${process.env.HOME}/.claude`, { recursive: true });
+    writeFileSync(KILL_FILE, ""); // empty file = manual kill, always active
+
+    let fetchCallCount = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCallCount++;
+      return new Response("[]", { status: 200 });
+    }) as any;
+
+    await refreshChannelList("Bot fake-token");
+
+    // The kill switch must short-circuit BEFORE any outbound API call.
+    // This is the load-bearing assertion: the bug allowed the refresh
+    // timer to fire during cooldown and re-burst the API.
+    expect(fetchCallCount).toBe(0);
+  });
+
+  test("returns early when kill switch has a future expiry timestamp", async () => {
+    const { writeFileSync, mkdirSync } = await import("node:fs");
+    mkdirSync(`${process.env.HOME}/.claude`, { recursive: true });
+    const futureTs = Math.floor(Date.now() / 1000) + 3600; // +1 hour
+    writeFileSync(KILL_FILE, `${futureTs}\n`);
+
+    let fetchCallCount = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCallCount++;
+      return new Response("[]", { status: 200 });
+    }) as any;
+
+    await refreshChannelList("Bot fake-token");
+
+    expect(fetchCallCount).toBe(0);
+  });
+
+  test("calls fetchTextChannels when kill switch is clear", async () => {
+    // Ensure no kill file exists
+    const { unlinkSync } = await import("node:fs");
+    try { unlinkSync(KILL_FILE); } catch { /* ignore */ }
+
+    let fetchCallCount = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCallCount++;
+      // Return an empty channel list — simplest happy path
+      return new Response("[]", { status: 200 });
+    }) as any;
+
+    await refreshChannelList("Bot fake-token");
+
+    // At least the /guilds/<id>/channels call should have fired
+    expect(fetchCallCount).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Bug 1 — inter-channel jitter.** `checkForNewMessages()` was iterating all watched channels in a tight `for` loop, firing a burst of REST calls every 15 seconds with no staggering. Added `await sleep(nextChannelJitterMs())` (random `[50, 150)` ms) at the **top of the for-loop body** with an `isFirst` flag so it skips the first iteration but applies between every subsequent channel — covering all early-`continue` paths.
- **Bug 2 — kill-switch-aware refresh.** The 5-minute channel refresh `setInterval` callback didn't check the kill switch before firing, so during a 429 cooldown it could re-burst the API independently of the main poll loop's pause. Extracted `refreshChannelList(authHeader)` as an exported function with `if (checkKillSwitch() === "active") return;` at line 1, plus an additional intra-loop kill-switch re-check so a mid-refresh 429 doesn't leak N-1 burst calls.

## Changes

- `index.ts`:
  - New constants `INTER_CHANNEL_JITTER_MIN_MS = 50`, `INTER_CHANNEL_JITTER_MAX_MS = 150`
  - New file-private `sleep(ms)` helper
  - New exported pure function `nextChannelJitterMs()` returning random in `[50, 150)`
  - New exported async function `refreshChannelList(authHeader)` containing the previously-inline setInterval body, with kill-switch checks at function entry AND inside the inner channel-baseline loop
  - `checkForNewMessages()` per-channel loop: jitter sleep at the **top** of the loop body with an `isFirst` flag (skips the first channel, applies between all others, covers `continue` paths)
  - `main()`'s refresh setInterval collapsed from 30 lines of inline logic to a 5-line `refreshChannelList(authHeader).catch(...)` call
- `tests/index.test.ts`: added 5 new tests across `nextChannelJitterMs` (range, distribution) and `refreshChannelList` (kill-switch active manual, kill-switch with future expiry timestamp, happy path)

## Linked Issues

Closes #9

## Test Plan

- [x] `scripts/ci/validate.sh` — clean (shellcheck on 7 scripts, `bun run lint` strict-mode TypeScript, `bun test`)
- [x] `bun test` — 77 pass / 0 fail (was 72 before)
- [x] `feature-dev:code-reviewer` agent run; **2 substantive findings, both fixed before this PR**:
  - **Critical (confidence 95):** Original implementation had the jitter sleep at the END of the loop body, but the first-poll baseline `continue` made an API call AND skipped the sleep. Fixed by moving the sleep to the TOP of the loop body with `isFirst` flag — now covers ALL `continue` paths.
  - **Important (confidence 85):** `refreshChannelList` only checked the kill switch at function entry, leaving room for N-1 burst calls if a baseline call mid-refresh tripped a 429. Fixed by adding `if (checkKillSwitch() === "active") break;` at the top of the inner channel-baseline loop.
- [ ] Bug 1 manual exercise on a real multi-channel guild not yet performed — covered by unit tests on the helper function and reasoning about the loop structure