### PR TITLE
fix(instructions): point agents at disc-server MCP tools instead of nonexistent discord-bot CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ on a Discord server and pushes wake-up notifications into the Claude Code
 session when new messages arrive.
 
 This is a "doorbell, not a mailroom" — it notifies the agent that something new
-appeared, then the agent uses `discord-bot read/send` to interact.
+appeared, then the agent uses the `disc_read` and `disc_send` MCP tools (from
+the `disc-server` MCP server) to interact.
 
 ## Prerequisites
 

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,8 @@
  * wake-up notifications into the Claude Code session when new messages arrive.
  *
  * This is a "doorbell, not a mailroom" — it notifies the agent that something
- * new appeared, then the agent uses discord-bot read/send to interact.
+ * new appeared, then the agent uses the disc_read / disc_send MCP tools (from
+ * the disc-server MCP server) to interact.
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -732,8 +733,8 @@ const INSTRUCTIONS = [
   'Discord messages arrive as <channel source="discord_watcher" channel_name="..." channel_id="..." author="...">.',
   "Messages are pre-filtered: you only receive messages addressed to @all, @<Dev-Team>, @<Dev-Name>, or replies to messages you signed.",
   "When you see a notification:",
-  "1. Run: discord-bot read <channel_id> --limit 10",
-  "2. Process the message and respond via discord-bot send if action is needed.",
+  "1. Call the mcp__disc-server__disc_read tool with channel_id and limit: 10 to fetch recent messages in context.",
+  "2. Process the message and respond by calling mcp__disc-server__disc_send if action is needed.",
   '3. Sign every message with: — **<dev-name>** <dev-avatar> (<dev-team>). The watcher filters your own echoes by this signature, and uses it to route replies back to you.',
 ].join("\n");
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -345,6 +345,43 @@ describe("DiscordMessage with attachments", () => {
   });
 });
 
+// --- MCP INSTRUCTIONS string tests -------------------------------------------
+//
+// Regression suite for issue #3. The watcher's MCP `instructions` string is
+// surfaced to every Claude Code session that loads the watcher as system-
+// reminder context, telling agents how to read and reply to Discord messages.
+// Originally it told agents to run a `discord-bot` shell CLI that does not
+// exist. The fix points agents at the disc_read / disc_send MCP tools from
+// the sibling disc-server MCP, which IS available in any session that loads
+// the watcher.
+//
+// These tests are source-reading checks because INSTRUCTIONS is a private
+// const inside index.ts, not an exported value. They lock in the contract:
+// the new MCP tool references must be present, and the broken CLI references
+// must NOT regress.
+
+describe("MCP server INSTRUCTIONS string", () => {
+  test("references disc_read and disc_send MCP tools, not discord-bot CLI", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../index.ts", import.meta.url).pathname,
+      "utf-8"
+    );
+
+    // Old broken CLI references must NOT regress
+    expect(src).not.toContain("discord-bot read");
+    expect(src).not.toContain("discord-bot send");
+
+    // New MCP tool references must be present
+    expect(src).toContain("disc_read");
+    expect(src).toContain("disc_send");
+
+    // The MCP server name should be mentioned so agents know where the tools
+    // come from (helps disambiguate from other Discord MCP servers)
+    expect(src).toContain("disc-server");
+  });
+});
+
 // --- STT configuration tests -------------------------------------------------
 
 describe("STT configuration", () => {


### PR DESCRIPTION
## Summary

The watcher's MCP `INSTRUCTIONS` string told every agent to run `discord-bot read <channel_id>` and `discord-bot send` as shell commands, but no such CLI binary exists. Agents in fresh sessions dutifully followed the instructions and hit `command not found`. The replacement is the `disc-server` MCP tools (`mcp__disc-server__disc_read`, `mcp__disc-server__disc_send`), which are already available in any session that loads the watcher.

## Changes

- `index.ts` `INSTRUCTIONS` const: replaced the two CLI references with the **explicit namespaced** MCP tool identifiers per code-review feedback. Natural-language descriptions like "Call the disc_read MCP tool (from the disc-server MCP server)" require fuzzy-matching to the agent's tool list — the namespaced form `mcp__disc-server__disc_read` is unambiguous and matches how Claude Code identifies tools.
- `index.ts` file header docstring (lines 1-9): same fix in the "doorbell, not a mailroom" prose. **Caught by the new structural test during development** — I would have missed this otherwise.
- `README.md` line 8: same fix in the matching README prose.
- `tests/index.test.ts`: new `MCP server INSTRUCTIONS string` describe block. Source-reading regression test asserts the source contains `disc_read`, `disc_send`, `disc-server` and does NOT contain `discord-bot read` / `discord-bot send`.

**Intentionally NOT changed:**
- `KILL_FILE = ~/.claude/discord-bot.kill` — legacy on-disk file format. Renaming would break existing deployments.
- `DEFAULT_TOKEN_PATH = ~/secrets/discord-bot-token` — legacy filename convention.
- Comments referencing the historical `discord-bot` shell script's kill-file format compatibility.

The new test's negative assertions are scoped to `"discord-bot read"` and `"discord-bot send"` substrings, neither of which appears in these legacy identifiers.

## Linked Issues

Closes #3

## Test Plan

- [x] `scripts/ci/validate.sh` — clean (shellcheck on 7 scripts, `bun run lint` strict-mode TypeScript, `bun test`)
- [x] `bun test` — 78 pass / 0 fail (was 77 before)
- [x] `feature-dev:code-reviewer` agent run; **1 substantive finding fixed before this PR**:
  - **Important (confidence 82):** Initial wording was "Call the disc_read MCP tool (from the disc-server MCP server)" — natural language requiring agents to fuzzy-match to their tool list. **Fixed** to use the explicit namespaced form `mcp__disc-server__disc_read` and `mcp__disc-server__disc_send`. The structural test still passes because the substring assertions (`disc_read`, `disc_send`, `disc-server`) are all contained within the namespaced form.
- [x] Issue #3 relabeled with the proper `type::bug, severity::major, priority::high, urgency::soon` taxonomy (was using only the basic `bug` label).

## Operational note

After this PR merges, **active Claude Code sessions will continue to show the OLD instructions** until the watcher binary is rebuilt and reinstalled (`./scripts/install.sh` from a dev clone, or the released-binary equivalent). This is expected — the MCP server's `instructions` field is read at session start. New sessions started after the rebuild will see the corrected instructions.