### PR TITLE
fix(auth): add 401 circuit breaker so bad tokens don't silently suppress all notifications

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -173,6 +173,66 @@ export function engageKillSwitch(retryAfterSeconds: number): void {
   }
 }
 
+// --- Auth-failure circuit breaker --------------------------------------------
+//
+// Distinct from the kill switch (which handles transient 429s with auto-lift):
+// auth failure is a *permanent* state for the current bot token. Once Discord
+// returns 401 the token is expired/revoked and no amount of retrying will fix
+// it — only operator intervention (new token + watcher restart) recovers.
+//
+// State lives in a sentinel file at ~/.claude/discord-bot.auth-failed. The
+// file is cleared at watcher startup (clearAuthFailed in main()) so a fresh
+// process with a fresh token retries cleanly.
+
+const AUTH_FAILED_FILE = join(homedir(), ".claude", "discord-bot.auth-failed");
+
+/**
+ * Returns true if the auth-failed sentinel file exists. The watcher uses
+ * this to short-circuit polling and channel-refresh cycles when the bot
+ * token is known to be bad.
+ */
+export function checkAuthFailed(): boolean {
+  return existsSync(AUTH_FAILED_FILE);
+}
+
+/**
+ * Engage the auth-failure circuit breaker. Called from `apiGet` when Discord
+ * returns 401 Unauthorized. Idempotent — only logs and writes the sentinel
+ * file once per process so repeated 401s during a single poll cycle don't
+ * spam stderr.
+ */
+export function engageAuthFailed(): void {
+  if (existsSync(AUTH_FAILED_FILE)) return;
+  try {
+    writeFileSync(
+      AUTH_FAILED_FILE,
+      `${new Date().toISOString()} Discord 401 Unauthorized\n`
+    );
+    console.error(
+      "[discord-watcher] AUTH FAILURE: Discord returned 401 Unauthorized. " +
+      "Bot token is expired or revoked. Polling suspended until you update " +
+      "the token and restart the watcher."
+    );
+  } catch (err) {
+    console.error(
+      `[discord-watcher] Failed to write auth-failed sentinel: ${err}`
+    );
+  }
+}
+
+/**
+ * Clear the auth-failed sentinel file. Called from `main()` at watcher
+ * startup so a fresh process with a fresh token retries cleanly. Idempotent —
+ * silently does nothing if the file does not exist.
+ */
+export function clearAuthFailed(): void {
+  try {
+    unlinkSync(AUTH_FAILED_FILE);
+  } catch {
+    // File doesn't exist — nothing to clear
+  }
+}
+
 // --- Scream-hole health check ------------------------------------------------
 
 /**
@@ -275,6 +335,14 @@ async function apiGet(
     const retryAfter = parseFloat(res.headers.get("Retry-After") ?? "5");
     engageKillSwitch(retryAfter);
     return { ok: false, status: 429, retryAfter };
+  }
+  if (res.status === 401) {
+    // Bot token is expired or revoked. Engage the auth-failure circuit
+    // breaker so subsequent poll cycles short-circuit instead of spamming
+    // 401s every 15 seconds. Recovery requires operator intervention
+    // (new token + watcher restart).
+    engageAuthFailed();
+    return { ok: false, status: 401 };
   }
   if (!res.ok) {
     return { ok: false, status: res.status };
@@ -577,6 +645,15 @@ async function fetchAllNewMessages(
         await new Promise((r) => setTimeout(r, result.retryAfter! * 1000));
         continue;
       }
+      if (result.status === 401) {
+        // Auth failure already engaged by apiGet via engageAuthFailed().
+        // Return what we've collected so far (typically empty) and let
+        // the caller's checkAuthFailed() guard handle the cleanup. Throwing
+        // here would cause checkForNewMessages's per-channel catch to log
+        // a misleading "Error polling #<channel>" line that looks like a
+        // crash, immediately after the "AUTH FAILURE" line we want.
+        return allMessages;
+      }
       throw new Error(`Discord API HTTP ${result.status}`);
     }
 
@@ -596,25 +673,27 @@ async function fetchAllNewMessages(
 }
 
 /**
- * Refresh the watched channel list. Honors the kill switch — when the
- * watcher is in cooldown after a 429, this is a no-op so the refresh
- * timer doesn't independently re-burst the API while the main poll loop
- * is paused.
+ * Refresh the watched channel list. Honors both circuit breakers — when the
+ * watcher is in 429 cooldown OR has hit a permanent 401 auth failure, this
+ * is a no-op so the refresh timer doesn't independently re-burst the API
+ * while the main poll loop is paused.
  *
  * Mutates module-level `watchedChannels` and `lastSeenMessageId` on
- * successful refresh. Exported so the kill-switch short-circuit can be
+ * successful refresh. Exported so the circuit-breaker short-circuits can be
  * exercised in unit tests.
  */
 export async function refreshChannelList(authHeader: string): Promise<void> {
   if (checkKillSwitch() === "active") return;
+  if (checkAuthFailed()) return;
 
   const fresh = await fetchTextChannels(authHeader);
   for (const ch of fresh) {
-    // Re-check kill switch between baseline calls — if a baseline
-    // request inside this loop trips a 429 and engages the kill switch,
-    // we should stop firing more requests in the same refresh cycle
-    // rather than continue bursting through every newly discovered channel.
+    // Re-check both circuit breakers between baseline calls — if a baseline
+    // request inside this loop trips a 429 OR a 401, we should stop firing
+    // more requests in the same refresh cycle rather than continue bursting
+    // through every newly discovered channel.
     if (checkKillSwitch() === "active") break;
+    if (checkAuthFailed()) break;
 
     if (!lastSeenMessageId.has(ch.id)) {
       try {
@@ -634,12 +713,59 @@ export async function refreshChannelList(authHeader: string): Promise<void> {
   console.error(`[discord-watcher] Refreshed: ${fresh.length} channels`);
 }
 
+// One-time MCP notification flag for auth failure. The notification is sent
+// once per process so a Claude session is alerted exactly once that the
+// watcher has stopped delivering messages due to a bad token. Reset on
+// process restart (module re-import) — paired with clearAuthFailed() in main().
+let authFailureNotificationSent = false;
+
+/**
+ * Emit a one-time MCP notification informing the Claude session that the
+ * watcher has hit an auth failure and polling is suspended. Idempotent —
+ * subsequent calls in the same process are no-ops.
+ */
+async function emitAuthFailedNotificationIfNeeded(server: Server): Promise<void> {
+  if (authFailureNotificationSent) return;
+  authFailureNotificationSent = true;
+  try {
+    await server.notification({
+      method: "notifications/claude/channel" as any,
+      params: {
+        content:
+          "[discord-watcher] AUTH FAILURE: Discord returned 401 Unauthorized. " +
+          "The bot token is expired or revoked. Notification polling is " +
+          "suspended until the operator updates ~/secrets/discord-bot-token " +
+          "(or DISCORD_BOT_TOKEN env var) and restarts the watcher.",
+        meta: {
+          channel_name: "system",
+          channel_id: "auth-failure",
+          author: "discord-watcher",
+          message_id: `auth-failure-${Date.now()}`,
+        },
+      },
+    });
+  } catch (err) {
+    console.error(
+      `[discord-watcher] Failed to emit auth-failed notification: ${err}`
+    );
+  }
+}
+
 async function checkForNewMessages(
   server: Server,
   authHeader: string
 ): Promise<void> {
   // Check kill switch before polling
   if (checkKillSwitch() === "active") return;
+
+  // Check auth-failure circuit breaker. If the bot token has been revoked
+  // or expired, polling is permanently suspended for this process. Emit a
+  // one-time MCP notification so the Claude session knows why notifications
+  // have stopped, then short-circuit every subsequent cycle silently.
+  if (checkAuthFailed()) {
+    await emitAuthFailedNotificationIfNeeded(server);
+    return;
+  }
 
   // Refresh identity each cycle (agent may pick name after server starts)
   cachedIdentity = resolveIdentity();
@@ -723,6 +849,16 @@ async function checkForNewMessages(
         `[discord-watcher] Error polling #${channel.name}: ${err}`
       );
     }
+
+    // If a 401 was caught mid-cycle (apiGet engaged the auth-failure
+    // circuit breaker), break out of the channel loop immediately rather
+    // than continue firing 401s for every remaining channel. Emit the
+    // one-time MCP notification on the way out so the Claude session is
+    // alerted within this cycle, not the next one.
+    if (checkAuthFailed()) {
+      await emitAuthFailedNotificationIfNeeded(server);
+      break;
+    }
   }
 
 }
@@ -739,6 +875,12 @@ const INSTRUCTIONS = [
 ].join("\n");
 
 async function main(): Promise<void> {
+  // Clear any stale auth-failed sentinel from a previous process. This is
+  // the recovery handshake: an operator who has updated the bot token and
+  // restarted the watcher gets a clean retry. If the new token is also
+  // bad, the first apiGet 401 will re-engage the circuit breaker.
+  clearAuthFailed();
+
   // Load token early — fail fast before MCP transport setup
   const token = loadToken();
   const authHeader = `Bot ${token}`;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -15,6 +15,9 @@ import {
   loadConfig,
   checkKillSwitch,
   engageKillSwitch,
+  checkAuthFailed,
+  engageAuthFailed,
+  clearAuthFailed,
   checkScreamHoleHealth,
   resolveApiBase,
   shouldDeliverMessage,
@@ -878,6 +881,148 @@ describe("kill switch", () => {
     const content = read(KILL_FILE, "utf-8").trim();
     // Must be a plain integer (Unix timestamp) — discord-bot checks with regex ^[0-9]+$
     expect(content).toMatch(/^\d+$/);
+  });
+});
+
+// --- Auth-failure circuit breaker tests --------------------------------------
+//
+// Regression suite for issue #8. The watcher previously caught 401 responses
+// in the per-channel error handler, logged them, and continued polling
+// forever — silently delivering zero notifications. The fix adds a sentinel-
+// file-backed circuit breaker (mirroring the kill switch pattern) that
+// engages on first 401, short-circuits subsequent polls, emits a one-time
+// MCP notification to the Claude session, and is cleared on watcher restart.
+
+describe("auth-failure circuit breaker", () => {
+  const AUTH_FAILED_FILE = `${process.env.HOME}/.claude/discord-bot.auth-failed`;
+
+  afterEach(async () => {
+    // Clean up sentinel file after each test
+    const { unlinkSync: unlink } = await import("node:fs");
+    try { unlink(AUTH_FAILED_FILE); } catch { /* ignore if not exists */ }
+  });
+
+  test("checkAuthFailed returns false when sentinel file does not exist", () => {
+    // Ensure file doesn't exist
+    const { unlinkSync: unlink } = require("node:fs");
+    try { unlink(AUTH_FAILED_FILE); } catch { /* ignore */ }
+
+    expect(checkAuthFailed()).toBe(false);
+  });
+
+  test("engageAuthFailed creates the sentinel file with an ISO timestamp", async () => {
+    const { existsSync, readFileSync, mkdirSync } = await import("node:fs");
+    mkdirSync(`${process.env.HOME}/.claude`, { recursive: true });
+
+    engageAuthFailed();
+
+    expect(existsSync(AUTH_FAILED_FILE)).toBe(true);
+    const content = readFileSync(AUTH_FAILED_FILE, "utf-8");
+    // ISO timestamp prefix + the canonical reason string
+    expect(content).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(content).toContain("401 Unauthorized");
+  });
+
+  test("engageAuthFailed is idempotent — second call does not overwrite", async () => {
+    const { existsSync, readFileSync, mkdirSync } = await import("node:fs");
+    mkdirSync(`${process.env.HOME}/.claude`, { recursive: true });
+
+    engageAuthFailed();
+    expect(existsSync(AUTH_FAILED_FILE)).toBe(true);
+    const firstContent = readFileSync(AUTH_FAILED_FILE, "utf-8");
+
+    // Wait a tick to ensure any second-write would have a different timestamp
+    await new Promise((r) => setTimeout(r, 10));
+
+    engageAuthFailed();
+    const secondContent = readFileSync(AUTH_FAILED_FILE, "utf-8");
+
+    expect(secondContent).toBe(firstContent);
+  });
+
+  test("checkAuthFailed returns true after engageAuthFailed", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(`${process.env.HOME}/.claude`, { recursive: true });
+
+    expect(checkAuthFailed()).toBe(false);
+    engageAuthFailed();
+    expect(checkAuthFailed()).toBe(true);
+  });
+
+  test("clearAuthFailed removes the sentinel file", async () => {
+    const { existsSync, mkdirSync } = await import("node:fs");
+    mkdirSync(`${process.env.HOME}/.claude`, { recursive: true });
+
+    engageAuthFailed();
+    expect(existsSync(AUTH_FAILED_FILE)).toBe(true);
+
+    clearAuthFailed();
+    expect(existsSync(AUTH_FAILED_FILE)).toBe(false);
+    expect(checkAuthFailed()).toBe(false);
+  });
+
+  test("clearAuthFailed is idempotent when sentinel does not exist", () => {
+    // No file, no error
+    expect(() => clearAuthFailed()).not.toThrow();
+    expect(checkAuthFailed()).toBe(false);
+  });
+});
+
+describe("refreshChannelList: auth-failure integration", () => {
+  let originalFetch: typeof globalThis.fetch;
+  const AUTH_FAILED_FILE = `${process.env.HOME}/.claude/discord-bot.auth-failed`;
+  const KILL_FILE = `${process.env.HOME}/.claude/discord-bot.kill`;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    const { unlinkSync } = await import("node:fs");
+    try { unlinkSync(AUTH_FAILED_FILE); } catch { /* ignore */ }
+    try { unlinkSync(KILL_FILE); } catch { /* ignore */ }
+  });
+
+  test("returns early without fetch when auth-failed sentinel exists", async () => {
+    const { writeFileSync, mkdirSync } = await import("node:fs");
+    mkdirSync(`${process.env.HOME}/.claude`, { recursive: true });
+    writeFileSync(AUTH_FAILED_FILE, new Date().toISOString());
+
+    let fetchCallCount = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCallCount++;
+      return new Response("[]", { status: 200 });
+    }) as any;
+
+    await refreshChannelList("Bot fake-token");
+
+    expect(fetchCallCount).toBe(0);
+  });
+
+  test("engages auth-failed when fetchTextChannels returns 401", async () => {
+    // Ensure clean state
+    const { unlinkSync } = await import("node:fs");
+    try { unlinkSync(AUTH_FAILED_FILE); } catch { /* ignore */ }
+
+    expect(checkAuthFailed()).toBe(false);
+
+    globalThis.fetch = mock(async () => {
+      return new Response("Unauthorized", { status: 401 });
+    }) as any;
+
+    // refreshChannelList swallows fetchTextChannels errors via the outer
+    // catch in the setInterval wrapper, but inside the function the throw
+    // propagates. We catch it here so the test continues to the assertion.
+    try {
+      await refreshChannelList("Bot fake-token");
+    } catch {
+      // Expected — fetchTextChannels throws on non-OK
+    }
+
+    // The 401 should have been intercepted by apiGet → engageAuthFailed,
+    // regardless of whether the throw bubbled up
+    expect(checkAuthFailed()).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Persistent Discord 401 Unauthorized responses were silently swallowed by the per-channel error handler in `checkForNewMessages()`. A user with an expired or revoked bot token would receive **zero notifications forever**, with no error surfaced to the Claude session or operator. The kill switch only handled 429 (rate limit), not 401 (auth). This PR adds an auth-failure circuit breaker mirroring the kill-switch pattern.

## Changes

- **New auth-failure circuit breaker in `index.ts`:**
  - `AUTH_FAILED_FILE = ~/.claude/discord-bot.auth-failed` sentinel
  - `checkAuthFailed(): boolean` / `engageAuthFailed(): void` / `clearAuthFailed(): void` — exported helpers paralleling the kill-switch pattern. `engageAuthFailed` is idempotent (only writes+logs once per process).
- **`apiGet`**: detects `res.status === 401` → calls `engageAuthFailed()` → returns `{ok: false, status: 401}`. Mirrors the existing 429 → `engageKillSwitch` branch one line above.
- **`fetchAllNewMessages`**: returns cleanly on 401 instead of throwing `Discord API HTTP 401`. Avoids a misleading double-log where `AUTH FAILURE: ...` is immediately followed by `Error polling #<channel>: Error: Discord API HTTP 401` that makes the controlled shutdown look like a crash. **Caught by code review.**
- **`checkForNewMessages`**: short-circuits at function entry when `checkAuthFailed()` is true, emitting a one-time MCP notification via `authFailureNotificationSent` flag. Also breaks the per-channel for-loop on mid-cycle 401 detection so the first cycle doesn't continue iterating.
- **`refreshChannelList`**: honors the new circuit breaker the same way it honors the kill switch (short-circuit at function entry AND inside the inner channel-baseline loop).
- **`main()`**: calls `clearAuthFailed()` at startup. Recovery handshake — operator updates token, restarts watcher, sentinel cleared, polling resumes.

MCP notification uses the existing `notifications/claude/channel` method with `meta.channel_name = "system"` / `channel_id = "auth-failure"` rather than inventing a new method for one error path.

## Linked Issues

Closes #8

## Test Plan

- [x] `scripts/ci/validate.sh` — clean (shellcheck + tsc strict + bun test)
- [x] `bun test` — 86 pass / 0 fail (was 78 before)
- [x] `feature-dev:code-reviewer` agent run. **1 substantive finding fixed before this PR** (confidence 85): `fetchAllNewMessages` was throwing on 401 causing a misleading double-log. **Fixed** by adding an explicit `result.status === 401` early-return that returns `allMessages` (typically empty) and lets the caller's `checkAuthFailed()` guard handle cleanup.
- [x] 5 of 6 code-reviewer questions confirmed correct (recovery handshake, sentinel race-condition non-issue under single-process assumption, persistence semantics, `as any` cast precedent, manual `rm` recovery path works).
- [ ] **Deferred to follow-up:** code reviewer noted pre-existing `setInterval` reentrancy in `checkForNewMessages` (not introduced by this PR). The `authFailureNotificationSent` and idempotent `engageAuthFailed` correctly handle the duplicate-fire case, so it's not a blocker. Will file as a separate issue after this lands — a single `pollInFlight` boolean guard would close it cleanly.

## Operational note

After this PR merges, active Claude Code sessions will continue using the current watcher binary until it's rebuilt and reinstalled. To pick up the 401 detection behavior, run `./scripts/install.sh` from the dev clone (or wait for the next release if using the remote installer).