### PR TITLE
fix(scream-hole): fix URL construction and health check routing

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -229,22 +229,57 @@ export function clearAuthFailed(): void {
 // --- Scream-hole health check ------------------------------------------------
 
 /**
+ * Extract the origin (scheme + host + port) from a URL string, stripping any
+ * path components. Used to hit the health endpoint at the root of the
+ * scream-hole proxy regardless of whether the config URL includes `/api/v10`.
+ */
+export function extractOrigin(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return parsed.origin;
+  } catch {
+    // If URL parsing fails, strip trailing slashes and path as best we can
+    return url.replace(/\/+$/, "").replace(/\/api\/v10\/?$/, "");
+  }
+}
+
+/**
  * Check if scream-hole is reachable by hitting its /health endpoint.
+ * Always hits the origin root (e.g. https://host/health), regardless of
+ * whether the configured URL includes /api/v10.
  * Returns true if reachable, false otherwise.
  */
 export async function checkScreamHoleHealth(url: string): Promise<boolean> {
+  const origin = extractOrigin(url);
+  const healthUrl = `${origin}/health`;
   try {
-    const healthUrl = `${url.replace(/\/+$/, "")}/health`;
+    log.debug("health_check", { url: healthUrl });
     const res = await fetch(healthUrl, { signal: AbortSignal.timeout(5000) });
+    log.debug("health_check", { url: healthUrl, status: res.status, ok: res.ok });
     return res.ok;
-  } catch {
+  } catch (err) {
+    log.debug("health_check", { url: healthUrl, error: String(err) });
     return false;
   }
 }
 
 /**
+ * Ensure a scream-hole URL ends with `/api/v10` (the Discord-compatible API
+ * prefix). Handles both forms:
+ *   - Origin only: `https://host` → `https://host/api/v10`
+ *   - Already suffixed: `https://host/api/v10/` → `https://host/api/v10`
+ */
+export function ensureApiV10Suffix(url: string): string {
+  const stripped = url.replace(/\/+$/, "");
+  if (/\/api\/v10$/.test(stripped)) {
+    return stripped;
+  }
+  return `${stripped}/api/v10`;
+}
+
+/**
  * Resolve which API base URL to use. If scream-hole is configured and reachable,
- * use it; otherwise fall back to direct Discord API.
+ * use it (with /api/v10 suffix); otherwise fall back to direct Discord API.
  */
 export async function resolveApiBase(screamHoleUrl: string | null): Promise<string> {
   if (!screamHoleUrl) {
@@ -254,7 +289,7 @@ export async function resolveApiBase(screamHoleUrl: string | null): Promise<stri
 
   const healthy = await checkScreamHoleHealth(screamHoleUrl);
   if (healthy) {
-    const baseUrl = screamHoleUrl.replace(/\/+$/, "");
+    const baseUrl = ensureApiV10Suffix(screamHoleUrl);
     log.info("state_change", { what: "mode", to: "scream-hole", url: baseUrl });
     return baseUrl;
   }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -18,7 +18,9 @@ import {
   checkAuthFailed,
   engageAuthFailed,
   clearAuthFailed,
+  extractOrigin,
   checkScreamHoleHealth,
+  ensureApiV10Suffix,
   resolveApiBase,
   shouldDeliverMessage,
   isReplyToOurSignature,
@@ -1144,6 +1146,74 @@ describe("loadConfig", () => {
   });
 });
 
+// --- extractOrigin tests -----------------------------------------------------
+
+describe("extractOrigin", () => {
+  test("extracts origin from bare URL", () => {
+    expect(extractOrigin("https://scream-hole.apps.oakai.waveeng.com")).toBe(
+      "https://scream-hole.apps.oakai.waveeng.com"
+    );
+  });
+
+  test("extracts origin from URL with /api/v10 path", () => {
+    expect(extractOrigin("https://scream-hole.apps.oakai.waveeng.com/api/v10")).toBe(
+      "https://scream-hole.apps.oakai.waveeng.com"
+    );
+  });
+
+  test("extracts origin from URL with /api/v10/ trailing slash", () => {
+    expect(extractOrigin("https://scream-hole.apps.oakai.waveeng.com/api/v10/")).toBe(
+      "https://scream-hole.apps.oakai.waveeng.com"
+    );
+  });
+
+  test("extracts origin from URL with port", () => {
+    expect(extractOrigin("http://scream-hole:3000/api/v10")).toBe(
+      "http://scream-hole:3000"
+    );
+  });
+
+  test("extracts origin from bare URL with trailing slash", () => {
+    expect(extractOrigin("http://scream-hole:3000/")).toBe(
+      "http://scream-hole:3000"
+    );
+  });
+});
+
+// --- ensureApiV10Suffix tests ------------------------------------------------
+
+describe("ensureApiV10Suffix", () => {
+  test("appends /api/v10 to bare origin", () => {
+    expect(ensureApiV10Suffix("https://scream-hole.apps.oakai.waveeng.com")).toBe(
+      "https://scream-hole.apps.oakai.waveeng.com/api/v10"
+    );
+  });
+
+  test("does not double-append when URL already has /api/v10", () => {
+    expect(ensureApiV10Suffix("https://scream-hole.apps.oakai.waveeng.com/api/v10")).toBe(
+      "https://scream-hole.apps.oakai.waveeng.com/api/v10"
+    );
+  });
+
+  test("strips trailing slash and does not double-append", () => {
+    expect(ensureApiV10Suffix("https://scream-hole.apps.oakai.waveeng.com/api/v10/")).toBe(
+      "https://scream-hole.apps.oakai.waveeng.com/api/v10"
+    );
+  });
+
+  test("works with port-based URL", () => {
+    expect(ensureApiV10Suffix("http://scream-hole:3000")).toBe(
+      "http://scream-hole:3000/api/v10"
+    );
+  });
+
+  test("strips trailing slash from bare origin before appending", () => {
+    expect(ensureApiV10Suffix("http://scream-hole:3000/")).toBe(
+      "http://scream-hole:3000/api/v10"
+    );
+  });
+});
+
 // --- Scream-hole health check tests ------------------------------------------
 
 describe("checkScreamHoleHealth", () => {
@@ -1196,6 +1266,33 @@ describe("checkScreamHoleHealth", () => {
     const result = await checkScreamHoleHealth("http://scream-hole:3000/");
     expect(result).toBe(true);
   });
+
+  test("hits origin /health even when URL includes /api/v10 path", async () => {
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      // Must hit the origin root, NOT /api/v10/health
+      expect(url).toBe("https://scream-hole.apps.oakai.waveeng.com/health");
+      return new Response("OK", { status: 200 });
+    }) as any;
+
+    const result = await checkScreamHoleHealth(
+      "https://scream-hole.apps.oakai.waveeng.com/api/v10"
+    );
+    expect(result).toBe(true);
+  });
+
+  test("hits origin /health even when URL includes /api/v10/ trailing slash", async () => {
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      expect(url).toBe("https://scream-hole.apps.oakai.waveeng.com/health");
+      return new Response("OK", { status: 200 });
+    }) as any;
+
+    const result = await checkScreamHoleHealth(
+      "https://scream-hole.apps.oakai.waveeng.com/api/v10/"
+    );
+    expect(result).toBe(true);
+  });
 });
 
 // --- resolveApiBase tests ----------------------------------------------------
@@ -1216,13 +1313,13 @@ describe("resolveApiBase", () => {
     expect(result).toBe(DISCORD_API_BASE);
   });
 
-  test("returns scream-hole URL when health check passes", async () => {
+  test("returns scream-hole URL with /api/v10 when health check passes", async () => {
     globalThis.fetch = mock(async () => {
       return new Response("OK", { status: 200 });
     }) as any;
 
     const result = await resolveApiBase("http://scream-hole:3000");
-    expect(result).toBe("http://scream-hole:3000");
+    expect(result).toBe("http://scream-hole:3000/api/v10");
   });
 
   test("returns Discord API base when scream-hole health check fails", async () => {
@@ -1234,13 +1331,31 @@ describe("resolveApiBase", () => {
     expect(result).toBe(DISCORD_API_BASE);
   });
 
-  test("strips trailing slashes from scream-hole URL", async () => {
+  test("strips trailing slashes and appends /api/v10", async () => {
     globalThis.fetch = mock(async () => {
       return new Response("OK", { status: 200 });
     }) as any;
 
     const result = await resolveApiBase("http://scream-hole:3000/");
-    expect(result).toBe("http://scream-hole:3000");
+    expect(result).toBe("http://scream-hole:3000/api/v10");
+  });
+
+  test("does not double-append /api/v10 when URL already has it", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response("OK", { status: 200 });
+    }) as any;
+
+    const result = await resolveApiBase("https://scream-hole.apps.oakai.waveeng.com/api/v10");
+    expect(result).toBe("https://scream-hole.apps.oakai.waveeng.com/api/v10");
+  });
+
+  test("handles URL with /api/v10/ trailing slash", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response("OK", { status: 200 });
+    }) as any;
+
+    const result = await resolveApiBase("https://scream-hole.apps.oakai.waveeng.com/api/v10/");
+    expect(result).toBe("https://scream-hole.apps.oakai.waveeng.com/api/v10");
   });
 
   test("returns Discord API base when scream-hole returns non-200", async () => {
@@ -1287,5 +1402,28 @@ describe("scream-hole source integration", () => {
 
     // fetchAllNewMessages must include after in query
     expect(src).toContain("messages?after=${cursor}&limit=");
+  });
+
+  test("resolveApiBase applies ensureApiV10Suffix (source verification)", () => {
+    const { readFileSync } = require("node:fs");
+    const src = readFileSync(
+      new URL("../index.ts", import.meta.url).pathname,
+      "utf-8"
+    );
+
+    // resolveApiBase must call ensureApiV10Suffix before returning
+    expect(src).toContain("ensureApiV10Suffix(screamHoleUrl)");
+  });
+
+  test("checkScreamHoleHealth uses extractOrigin for health URL (source verification)", () => {
+    const { readFileSync } = require("node:fs");
+    const src = readFileSync(
+      new URL("../index.ts", import.meta.url).pathname,
+      "utf-8"
+    );
+
+    // Health check must extract origin to avoid hitting /api/v10/health
+    expect(src).toContain("extractOrigin(url)");
+    expect(src).toContain("${origin}/health");
   });
 });


### PR DESCRIPTION
## Summary

Fixes the watcher's scream-hole routing which was configured but not working. Zero traffic was reaching scream-hole because `resolveApiBase()` returned the bare origin without `/api/v10`, and `checkScreamHoleHealth()` could hit the wrong path when the config URL included `/api/v10`.

## Changes

- **`ensureApiV10Suffix()`** — new helper that guarantees the resolved API base ends with `/api/v10`, handling both bare-origin and already-suffixed config URLs
- **`extractOrigin()`** — new helper that extracts `scheme://host:port` from any URL, so the health check always hits `/health` at the root regardless of config format
- **`checkScreamHoleHealth()`** — now uses `extractOrigin()` to hit the correct health endpoint; adds debug-level structured logging for the attempt, result, and any errors
- **`resolveApiBase()`** — now calls `ensureApiV10Suffix()` before returning, so `API_BASE` always includes the Discord API path prefix
- **Tests** — 15 new tests for `extractOrigin`, `ensureApiV10Suffix`, updated health check with `/api/v10` path, updated `resolveApiBase` expectations, source integration verification

## Linked Issues

Closes #19

## Test Plan

- `bun test` — 102 tests pass (552 assertions)
- `scripts/ci/validate.sh` ��� TypeScript lint, shellcheck, and all tests pass
- Manual verification pending: with config set, confirm traffic reaches scream-hole via @mother's logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)