### PR TITLE
chore(logging): demote per-poll api_call to debug, promote message-received to info

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -381,7 +381,7 @@ async function apiGet(
     log.warn("api_call", { method: "GET", endpoint: pathOnly, status: res.status, ms, service });
     return { ok: false, status: res.status };
   }
-  log.info("api_call", { method: "GET", endpoint: pathOnly, status: res.status, ms, service });
+  log.debug("api_call", { method: "GET", endpoint: pathOnly, status: res.status, ms, service });
   return { ok: true, data: await res.json() };
 }
 
@@ -894,7 +894,7 @@ async function checkForNewMessages(
             ? fullContent.slice(0, 100) + "…"
             : fullContent;
 
-        log.debug("poll", { channel: channel.name, author: msg.author.username });
+        log.info("poll", { channel: channel.name, author: msg.author.username });
 
         await server.notification({
           method: "notifications/claude/channel" as any,


### PR DESCRIPTION
## Summary

Demote successful 2xx `api_call` events from info to debug, and promote per-message-delivery `poll` events from debug to info. Net effect at default `LOG_LEVEL=info`: the per-channel-per-cycle storm disappears, but actual message arrivals remain visible.

## Changes

- `index.ts:384` — `log.info("api_call", ...)` → `log.debug(...)` for 2xx GETs
- `index.ts:897` — `log.debug("poll", { channel, author })` → `log.info(...)` for per-message-delivery
- Non-2xx api_call (warn/error at lines 367/376/381) intentionally unchanged
- Per-cycle summary at line 928 intentionally unchanged

## Linked Issues

Closes #24

## Test Plan

- [x] `./scripts/ci/validate.sh` — 102/0 (lint + typecheck + test)
- [x] `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings
- [x] Code-reviewer agent — LGTM (no fleet log consumers filter on level==info AND event==api_call; schema doc has no level requirement; these are the only two emission sites that need to flip together)
- [ ] Post-deploy manual smoke: tail `~/.claude/logs/mcp.jsonl` and confirm watcher line rate drops to roughly cycle-summary frequency, not per-channel-per-cycle