### PR TITLE
fix(ci): restore .npmrc auth for bun install against GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags: ["v*"]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -11,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: sudo apt-get install -y shellcheck
+      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: bun install
       - run: scripts/ci/validate.sh
 
@@ -31,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
+      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: bun install
       - run: scripts/ci/build.sh "$TARGET"
         env:


### PR DESCRIPTION
## Summary

Fixes the regression where `bun install` in the release workflow 401s against `npm.pkg.github.com` because the recent setup-bun → npm install migration dropped the implicit `.npmrc` auth the setup-bun action provided.

Mirrors the fix pattern just landed in the sister repo: Wave-Engineering/mcp-server-discord#49.

## Changes

- `.github/workflows/release.yml`: added `.npmrc` auth step before every `bun install` invocation (test + build jobs), plus workflow-level `permissions: { contents: read, packages: read }`. Release job keeps its job-level `contents: write` override intact.
- `.github/workflows/ci.yml`: added workflow-level `permissions: { contents: read, packages: read }` for defensive consistency. Existing `.npmrc` steps were already in place.

## Linked Issues

Closes #26

## Test Plan

- [x] `./scripts/ci/validate.sh` green in worktree (102 tests pass, clean lint + shellcheck)
- [ ] This PR's CI run green (auto-verified by merge queue)
- [ ] Post-merge: push throwaway `vX.Y.Z-test` tag to verify release workflow succeeds end-to-end; delete after
