### PR TITLE
fix(watcher): sanitize lone surrogates in pushed message previews

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,7 @@ import { readFileSync, writeFileSync, renameSync, existsSync, unlinkSync } from 
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
+import { sanitizeSurrogates } from "./sanitize.ts";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createLogger } from "@wave-engineering/mcp-logger";
@@ -896,14 +897,19 @@ async function checkForNewMessages(
 
         log.info("poll", { channel: channel.name, author: msg.author.username });
 
+        // Sanitize before the content lands in the receiving agent's transcript:
+        // a lone surrogate in a pulled username/preview would 400 its next request.
+        const safeAuthor = sanitizeSurrogates(msg.author.username);
+        const safePreview = sanitizeSurrogates(preview);
+
         await server.notification({
           method: "notifications/claude/channel" as any,
           params: {
-            content: `New message from ${msg.author.username} in #${channel.name}: ${preview}`,
+            content: `New message from ${safeAuthor} in #${channel.name}: ${safePreview}`,
             meta: {
               channel_name: channel.name,
               channel_id: channel.id,
-              author: msg.author.username,
+              author: safeAuthor,
               message_id: msg.id,
             },
           },

--- a/sanitize.test.ts
+++ b/sanitize.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "bun:test";
+import { sanitizeSurrogates } from "./sanitize.ts";
+
+const FFFD = "�";
+
+describe("sanitizeSurrogates (watcher)", () => {
+  test("plain text unchanged", () => {
+    expect(sanitizeSurrogates("hi there")).toBe("hi there");
+  });
+  test("preserves a valid surrogate pair (emoji)", () => {
+    expect(sanitizeSurrogates("a 🐟 b")).toBe("a 🐟 b");
+  });
+  test("lone high surrogate → U+FFFD", () => {
+    expect(sanitizeSurrogates("a\uD800b")).toBe(`a${FFFD}b`);
+  });
+  test("lone low surrogate → U+FFFD", () => {
+    expect(sanitizeSurrogates("a\uDC00b")).toBe(`a${FFFD}b`);
+  });
+  test("lone surrogate at end of string", () => {
+    expect(sanitizeSurrogates("end\uD83D")).toBe(`end${FFFD}`);
+  });
+  test("sanitized output is JSON-serializable", () => {
+    expect(() => JSON.stringify({ c: sanitizeSurrogates("x \uD800 y") })).not.toThrow();
+  });
+});

--- a/sanitize.ts
+++ b/sanitize.ts
@@ -1,0 +1,33 @@
+/**
+ * Lone-surrogate sanitization (watcher copy of the disc-server helper, #29/#56).
+ *
+ * The watcher pushes message previews (`author.username` + content) into the
+ * receiving agent's transcript. A lone unpaired UTF-16 surrogate in pulled
+ * content cannot be encoded as valid JSON and makes every subsequent API
+ * request 400 (`no low surrogate in string`), hard-jamming the session
+ * (incident 2026-06-19). Strip lone surrogates here — the watcher is a second
+ * ingestion boundary alongside `disc_read`.
+ *
+ * Valid surrogate pairs (emoji / astral chars) are preserved; only unpaired
+ * halves become U+FFFD.
+ */
+export function sanitizeSurrogates(s: string): string {
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const next = i + 1 < s.length ? s.charCodeAt(i + 1) : 0;
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        out += s[i] + s[i + 1];
+        i++;
+      } else {
+        out += "�";
+      }
+    } else if (c >= 0xdc00 && c <= 0xdfff) {
+      out += "�";
+    } else {
+      out += s[i];
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
The watcher pushes message previews (`author.username` + content) into the receiving agent's transcript — a second poison vector alongside `disc_read`. A lone unpaired UTF-16 surrogate would 400 the agent's next request and jam the session. Sanitize author + preview before the notification.

## Changes
- New watcher-local `sanitize.ts` (`sanitizeSurrogates` — replaces only unpaired surrogates with U+FFFD; valid emoji pairs preserved).
- Wire it into the notification push (author + preview).

## Scope note (important)
The "webhook-identity-aware echo-filter/addressing" originally scoped in #29 is **not needed**: the watcher's self-echo filter + addressing key on message **content** (the `— **dev-name**` signature + `@`-tokens), which webhook messages preserve; `author.id` is never used for self-filtering. So enabling per-agent webhook identity (mcp-server-discord#55) does **not** break watcher routing. The only future exposure — if agents drop the redundant `— **dev-name**` signature once the webhook shows their name — is noted as a conditional follow-up (naive author-username matching risks false-positive drops, so not done preemptively).

## Linked Issues
Closes #29

## Test Plan
- `bun test sanitize.test.ts` → 6/0; `./scripts/ci/validate.sh` → 108 pass / 0 fail; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)